### PR TITLE
Updated requirements for pip 6.0+ to include a session

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
+import uuid
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
 
 # parse requirements
-reqs = parse_requirements("requirements/common.txt")
+reqs = parse_requirements("requirements/common.txt", session=uuid.uuid1())
 
 setup(
     name="cmsplugin-bootstrap-carousel",


### PR DESCRIPTION
pip version 6.0 changed the method signature for `pip.req.parse_requirements`.
This means that the setup.py fails with something like:

File "<string>", line 20, in <module>
      File "/tmp/pip-Mqz36T-build/setup.py", line 29, in <module>    
        install_requires=[str(x).split(' ')[0] for x in reqs],
      File "/home/beton/works/dentech/env/local/lib/python2.7/site-packages/pip/req/req_file.py", line 19, in parse_requirements
        "parse_requirements() missing 1 required keyword argument: "
    TypeError: parse_requirements() missing 1 required keyword argument: 'session'