### PR TITLE
Fixing the style of import blocks across the repository.

### DIFF
--- a/cmsplugin_bootstrap_carousel/__init__.py
+++ b/cmsplugin_bootstrap_carousel/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import

--- a/cmsplugin_bootstrap_carousel/cms_plugins.py
+++ b/cmsplugin_bootstrap_carousel/cms_plugins.py
@@ -1,11 +1,17 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 import re
-from cms.plugin_base import CMSPluginBase
-from cms.plugin_pool import plugin_pool
-from cmsplugin_bootstrap_carousel.models import *
+
 from django.utils.translation import ugettext as _
 from django.contrib import admin
 from django.forms import ModelForm, ValidationError
+
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
+
+from .models import Carousel, CarouselItem
 
 
 class CarouselForm(ModelForm):

--- a/cmsplugin_bootstrap_carousel/models.py
+++ b/cmsplugin_bootstrap_carousel/models.py
@@ -1,5 +1,11 @@
-from django.conf import settings
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 from os.path import dirname
+
+from django.conf import settings
+
 if 'filer' in settings.INSTALLED_APPS:
     execfile(dirname(__file__)+"/models_filer.py")
 else:

--- a/cmsplugin_bootstrap_carousel/models_default.py
+++ b/cmsplugin_bootstrap_carousel/models_default.py
@@ -1,13 +1,17 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 import os
+from cStringIO import StringIO
+
 from django.db import models
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.translation import ugettext as _
 
-from cms.models.pluginmodel import CMSPlugin
 from PIL import Image
-from cStringIO import StringIO
+from cms.models.pluginmodel import CMSPlugin
 
 
 class Carousel(CMSPlugin):

--- a/cmsplugin_bootstrap_carousel/models_filer.py
+++ b/cmsplugin_bootstrap_carousel/models_filer.py
@@ -1,8 +1,13 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 import os
+
 from django.db import models
 from django.conf import settings
 from django.utils.translation import ugettext as _
+
 from filer.fields.image import FilerImageField
 from cms.models.pluginmodel import CMSPlugin
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -121,7 +121,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'mptt',
+    'treebeard',
     'cms',
     'cmsplugin_bootstrap_carousel',
     # Uncomment the next line to enable the admin:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 import os
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
Several style problems related to the import sections of python files
were fixed across the repository. These included adding missing file
encodings, fixing the order of the import statements to match the style
used elsewhere, and using explicit relative imports where possible.